### PR TITLE
Move tables from beam backfill to beam export

### DIFF
--- a/anyfin-platform/platform-composer/dags/cloudsql_to_bigquery/pg_schemas/main_schemas_state.json
+++ b/anyfin-platform/platform-composer/dags/cloudsql_to_bigquery/pg_schemas/main_schemas_state.json
@@ -122,7 +122,10 @@
     },
     "ts_column": "updated_at",
     "bq_partition_column": "created_at",
-    "backfill_method": "beam_backfill"
+    "backfill_method": "beam_export",
+    "query_by": "offset",
+    "step_size": "100000",
+    "ordered_by": "created_at"
   },
   "loans": {
     "schema": {
@@ -317,7 +320,10 @@
     },
     "ts_column" : "updated_at",
     "bq_partition_column": "created_at",
-    "backfill_method": "beam_backfill"
+    "backfill_method": "beam_export",
+    "query_by": "offset",
+    "step_size": "100000",
+    "ordered_by": "created_at"
   },
   "transactions": {
     "schema": {
@@ -373,7 +379,10 @@
     },
     "ts_column" : "COALESCE(updated_at, created_at)",
     "bq_partition_column": "created_at",
-    "backfill_method": "beam_backfill"
+    "backfill_method": "beam_export",
+    "query_by": "offset",
+    "step_size": "100000",
+    "ordered_by": "created_at"
   },
   "lenders": {
     "schema": {
@@ -760,7 +769,10 @@
     },
     "ts_column" : "updated_at",
     "bq_partition_column": "created_at",
-    "backfill_method": "beam_backfill"  
+    "backfill_method": "beam_export",
+    "query_by": "offset",
+    "step_size": "100000",
+    "ordered_by": "created_at"
   },
   "payouts": {
     "schema": {


### PR DESCRIPTION
Chose the 4 biggest tables that aren't currently exported with beam based on the following query on BQ:
```
SELECT
  table_id,
  CAST(row_count AS STRING FORMAT '999,999,999,999') row_count,
  CAST(size_bytes AS STRING FORMAT '999,999,999,999') size_bytes,
  CAST(size_bytes/row_count AS STRING FORMAT '999,999,999.99') size_per_row,
  TIMESTAMP_MILLIS(last_modified_time) AS last_modified_time
FROM
  `anyfin.main.__TABLES__`
ORDER BY
  size_bytes DESC
```

This will hopefully offload the main backfill beam pipeline