### PR TITLE
Risk variable library dag

### DIFF
--- a/anyfin-platform/platform-composer/dags/rvl_parsing.py
+++ b/anyfin-platform/platform-composer/dags/rvl_parsing.py
@@ -3,6 +3,9 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.providers.google.cloud.operators.dataflow import DataflowStartFlexTemplateOperator
 
+GCS_BUCKET = "anyfin-rvl"
+FLEX_TEMPLATES_DIR = "flex_templates"
+
 default_args = {
     'owner': 'ds-anyfin',
     'depends_on_past': False, 
@@ -23,7 +26,7 @@ dag = DAG(
 schufa_parser = DataflowStartFlexTemplateOperator(
     body={
         "launchParameter": {
-            "containerSpecGcsPath": "gs://sql-to-bq-etl/flex_templates/flex_template_schufa_parser",
+            "containerSpecGcsPath": f"gs://{GCS_BUCKET}/{FLEX_TEMPLATES_DIR}/flex_template_schufa_parser",
             "jobName": "schufaparser",
             "environment": {
                 "enableStreamingEngine": "false"
@@ -41,7 +44,7 @@ schufa_parser = DataflowStartFlexTemplateOperator(
 schufa_features = DataflowStartFlexTemplateOperator(
     body={
         "launchParameter": {
-            "containerSpecGcsPath": "gs://sql-to-bq-etl/flex_templates/flex_template_schufa_features",
+            "containerSpecGcsPath": "gs://{GCS_BUCKET}/{FLEX_TEMPLATES_DIR}/flex_template_schufa_features",
             "jobName": "schufafeatures",
             "environment": {
                 "enableStreamingEngine": "false"

--- a/anyfin-platform/platform-composer/dags/rvl_parsing.py
+++ b/anyfin-platform/platform-composer/dags/rvl_parsing.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.models import Variable
+from airflow.providers.google.cloud.operators.dataflow import DataflowStartFlexTemplateOperator
+
+default_args = {
+    'owner': 'ds-anyfin',
+    'depends_on_past': False, 
+    'retries': 0,
+    'email_on_failure': True,
+    'email': Variable.get('de_email', 'data-engineering@anyfin.com'),
+    'start_date': datetime(2022, 3, 21),
+}
+
+dag = DAG(
+    dag_id="risk-variable-library", 
+    default_args=default_args, 
+    schedule_interval="0 2 * * *",  # Run this DAG once per day
+    max_active_runs=1,
+    catchup=False
+)
+
+schufa_parser = DataflowStartFlexTemplateOperator(
+    body={
+        "launchParameter": {
+            "containerSpecGcsPath": "gs://sql-to-bq-etl/flex_templates/flex_template_schufa_parser",
+            "jobName": "schufaparser",
+            "environment": {
+                "enableStreamingEngine": "false"
+            },
+        }
+    },
+    task_id="schufa_parser",
+    location="europe-west1",
+    project_id="anyfin",
+    gcp_conn_id="postgres-bq-etl-con",
+    wait_until_finished=True,
+    dag=dag
+)
+
+schufa_features = DataflowStartFlexTemplateOperator(
+    body={
+        "launchParameter": {
+            "containerSpecGcsPath": "gs://sql-to-bq-etl/flex_templates/flex_template_schufa_features",
+            "jobName": "schufafeatures",
+            "environment": {
+                "enableStreamingEngine": "false"
+            },
+        }
+    },
+    task_id="schufa_features",
+    location="europe-west1",
+    project_id="anyfin",
+    gcp_conn_id="postgres-bq-etl-con",
+    wait_until_finished=True,
+    dag=dag
+)
+
+schufa_parser >> schufa_features


### PR DESCRIPTION
Added and tested the DAG in the new `platform` composer (Airflow v2.2.3, Composer  v2.0.7)
The pipeline runs successfully after setting up the gcp_conn_id for `postgres-bq-etl-con` (No issues parsing the JSON keyfile)
Once it's deployed in the old composer through GA, I will set it off