### PR TITLE
Update DAGs with timouts

### DIFF
--- a/anyfin-platform/platform-composer/dags/bigquery_daily_models.py
+++ b/anyfin-platform/platform-composer/dags/bigquery_daily_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from airflow import DAG
 
 from utils.DbtTaskFactory import DbtTaskFactory
@@ -15,6 +15,7 @@ default_args = {
     'retries': 0,
     'on_failure_callback': partial(slack_notification.task_fail_slack_alert, SLACK_CONNECTION),
     'start_date': datetime(2022, 4, 1),
+    'dagrun_timeout': timedelta(minutes=120)
 }
 
 dag = DAG(

--- a/anyfin-platform/platform-composer/dags/bigquery_dbt_models.py
+++ b/anyfin-platform/platform-composer/dags/bigquery_dbt_models.py
@@ -24,7 +24,7 @@ dag = DAG(
     dag_id="bigquery_dbt_models", 
     default_args=default_args, 
     schedule_interval=None,  
-    max_active_runs=1,
+    max_active_runs=3,
     catchup=False,
     concurrency=12
 )

--- a/anyfin-platform/platform-composer/dags/bigquery_segment_models.py
+++ b/anyfin-platform/platform-composer/dags/bigquery_segment_models.py
@@ -18,6 +18,7 @@ default_args = {
     'retry_delay': timedelta(minutes=30),
     'on_failure_callback': partial(slack_notification.task_fail_slack_alert, SLACK_CONNECTION),
     'start_date': datetime(2021, 6, 23),
+    'dagrun_timeout': timedelta(minutes=120)
 }
 
 dag = DAG(

--- a/anyfin-platform/platform-composer/dags/cloudsql_to_bigquery/postgres_bq_etl.py
+++ b/anyfin-platform/platform-composer/dags/cloudsql_to_bigquery/postgres_bq_etl.py
@@ -37,6 +37,7 @@ default_args = {
     'retries': 2,
     'retry_delay': timedelta(minutes=10),
     'on_failure_callback': partial(slack_notification.task_fail_slack_alert, SLACK_CONNECTION),
+    'orientation': "TB"
 }
 
 with DAG(
@@ -44,7 +45,7 @@ with DAG(
     default_args=default_args,
     catchup=False,
     schedule_interval=None,
-    max_active_runs=1,
+    max_active_runs=3,
     concurrency=12
 ) as dag:
 

--- a/anyfin-platform/platform-composer/dags/run_thrice_daily.py
+++ b/anyfin-platform/platform-composer/dags/run_thrice_daily.py
@@ -25,6 +25,7 @@ default_args = {
     'start_date': datetime(2022, 4, 1),
     'retries': 0,  # Do not retry as this will rerun all dbt models and ETLs again
     'retry_delay': timedelta(minutes=10),
+    'dagrun_timeout': timedelta(minutes=120),
     'on_failure_callback': partial(slack_notification.task_fail_slack_alert, SLACK_CONNECTION),
 }
 


### PR DESCRIPTION
This will update our existing dags to timeout after 2h in order to prevent DAGs that get stuck in running state. It also allows several ETLs and dbt models dag runs to run at the same time. (So we still get updated data while we fix the issue of the ever running DAG)