### PR TITLE
Update de metadata interval

### DIFF
--- a/anyfin-platform/platform-composer/dags/de_metadata.py
+++ b/anyfin-platform/platform-composer/dags/de_metadata.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.providers.google.cloud.transfers.postgres_to_gcs import PostgresToGCSOperator
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
@@ -39,6 +39,7 @@ default_args = {
     'owner': 'de-anyfin',
     'depends_on_past': False, 
     'retries': 0,
+    'dagrun_timeout': timedelta(minutes=20),
     'on_failure_callback': partial(slack_notification.task_fail_slack_alert, SLACK_CONNECTION),
     'start_date': datetime(2022, 3, 9),
 }
@@ -46,7 +47,7 @@ default_args = {
 dag = DAG(
     dag_id="de_metadata", 
     default_args=default_args, 
-    schedule_interval="0 1 * * *",  # Run this DAG once per day
+    schedule_interval="0 1-17/2 * * *",  # Run this DAG every day every two hours between 1 and 17 
     max_active_runs=1,
     catchup=False
 )

--- a/anyfin-platform/platform-composer/dags/de_metadata.py
+++ b/anyfin-platform/platform-composer/dags/de_metadata.py
@@ -47,7 +47,7 @@ default_args = {
 dag = DAG(
     dag_id="de_metadata", 
     default_args=default_args, 
-    schedule_interval="0 1-17/2 * * *",  # Run this DAG every day every two hours between 1 and 17 
+    schedule_interval="0 0/2 * * *",  # Run this DAG every day every two hourss 
     max_active_runs=1,
     catchup=False
 )


### PR DESCRIPTION
Typically the DAG's duration is >20 seconds, so I've changed that to every two hours in order to have more fresh metadata throughout the day which will make more sense for our alerts